### PR TITLE
sitemap specific domains configuration

### DIFF
--- a/lib/organic-sitemap.rb
+++ b/lib/organic-sitemap.rb
@@ -11,6 +11,7 @@ module OrganicSitemap
 
   define_setting :storage,          "redis"
   define_setting :key,              "sitemap-urls"
+  define_setting :domains
   define_setting :redis_connection, Redis.new(url: 'redis://127.0.0.1:6379')
   define_setting :expiry_time,      7.days
 end

--- a/lib/organic-sitemap/middleware/url_capture.rb
+++ b/lib/organic-sitemap/middleware/url_capture.rb
@@ -9,7 +9,7 @@ module OrganicSitemap
         status, headers, response = @app.call(env)
         request = Rack::Request.new env
         if sitemap_url(status, headers, response, request, env)
-          OrganicSitemap::RedisManager.add(env['REQUEST_PATH'])
+          OrganicSitemap::RedisManager.add(request.path_info)
         end
         [status, headers, response]
       end

--- a/lib/organic-sitemap/middleware/url_capture.rb
+++ b/lib/organic-sitemap/middleware/url_capture.rb
@@ -7,26 +7,29 @@ module OrganicSitemap
 
       def call(env)
         status, headers, response = @app.call(env)
-        if healthy_url(status, headers, response, env)
+        request = Rack::Request.new env
+        if sitemap_url(status, headers, response, request, env)
           OrganicSitemap::RedisManager.add(env['REQUEST_PATH'])
         end
         [status, headers, response]
       end
 
-      def healthy_url(status, headers, response, env)
-        success_response(status) && html_page(headers) && get_method?(env)
+      def sitemap_url(status, headers, response, request, env)
+        success_response(status) && html_page(response) && request.get? && is_expected_domain?(request)
       end
 
       def success_response(status)
         status == 200
       end
 
-      def html_page(headers)
-        headers["Content-Type"].include? "text/html"
+      def html_page(response)
+        response.content_type.include? "text/html"
       end
 
-      def get_method?(env)
-        env['REQUEST_METHOD'] == 'GET'
+      def is_expected_domain?(request)
+        # Any domain if not explicitly configured
+        return true if !OrganicSitemap.domains || OrganicSitemap.domains.empty?
+        OrganicSitemap.domains.include? request.host
       end
     end
   end


### PR DESCRIPTION
Configuration of public domains that will hold sitemap

Use of Rack::Request API, since app servers can manipulate ENV vars and header
